### PR TITLE
Enable dimensionality investigations

### DIFF
--- a/docs/source/vasp_d.ipynb
+++ b/docs/source/vasp_d.ipynb
@@ -44,13 +44,29 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While the `b_params` dictionary describes the details of the bootstrapping process, these are documented in the [diffusion module](./diffusion.html#kinisi.diffusion.MSDBootstrap). Here, we indicate that we only want to investigate diffusion in the *xy*-plane of the system."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "b_params = {'dimension': 'xy'}"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "xd = Xdatcar('./example_XDATCAR.gz')\n",
-    "diff = DiffusionAnalyzer.from_Xdatcar(xd, parser_params=p_params)"
+    "diff = DiffusionAnalyzer.from_Xdatcar(xd, parser_params=p_params, bootstrap_params=b_params)"
    ]
   },
   {


### PR DESCRIPTION
This PR will allow #13 to be closed. It enables control over which Cartesian dimensions the MSD and therefore diffusion is calculated in. 

*Note*: the reason for the keyword argument being in the `bootstrap_params` is that this will allow users to read the data in once and run each dimension individually without reading the data in again. In future this can be exposed to the API but currently it requires constructing things yourself. 