### PR TITLE
Bayesian bootstrap

### DIFF
--- a/kinisi/diffusion.py
+++ b/kinisi/diffusion.py
@@ -8,7 +8,7 @@ diffusion coefficient from a material.
 # author: Andrew R. McCluskey (arm61)
 
 import warnings
-from typing import List, Union
+from typing import List, Union, Any
 import numpy as np
 from scipy.stats import normaltest, linregress
 from scipy.linalg import pinvh
@@ -236,7 +236,7 @@ class Bootstrap:
 
     @staticmethod
     def sample_until_normal(array: np.ndarray,
-                            n_samples: int,
+                            n_samples: float,
                             n_resamples: int,
                             max_resamples: int,
                             alpha: float = 1e-3,
@@ -494,7 +494,7 @@ class MSDBootstrap(Bootstrap):
             if d_squared.size <= 1:
                 continue
             self._euclidian_displacements.append(Distribution(np.sqrt(d_squared.flatten())))
-            distro = self.sample_until_normal(d_squared, int(n_o[i]), n_resamples, max_resamples, alpha, random_state)
+            distro = self.sample_until_normal(d_squared, n_o[i], n_resamples, max_resamples, alpha, random_state)
             self._distributions.append(distro)
             self._n = np.append(self._n, d_squared.mean())
             self._s = np.append(self._s, np.std(distro.samples, ddof=1))
@@ -553,7 +553,7 @@ class TMSDBootstrap(Bootstrap):
                 continue
             self._n_o = np.append(self._n_o, n_o[i])
             self._euclidian_displacements.append(Distribution(np.sqrt(d_squared.flatten())))
-            distro = self.sample_until_normal(coll_motion, int(n_o[i] / d_squared.shape[0]), n_resamples, max_resamples,
+            distro = self.sample_until_normal(coll_motion, n_o[i] / d_squared.shape[0], n_resamples, max_resamples,
                                               alpha, random_state)
             self._distributions.append(distro)
             self._n = np.append(self._n, distro.n)
@@ -619,7 +619,7 @@ class MSCDBootstrap(Bootstrap):
                 continue
             self._n_o = np.append(self._n_o, n_o[i])
             self._euclidian_displacements.append(Distribution(np.sqrt(d_squared.flatten())))
-            distro = self.sample_until_normal(sq_chg_motion, int(n_o[i] / d_squared.shape[0]), n_resamples,
+            distro = self.sample_until_normal(sq_chg_motion, n_o[i] / d_squared.shape[0], n_resamples,
                                               max_resamples, alpha, random_state)
             self._distributions.append(distro)
             self._n = np.append(self._n, distro.n)
@@ -630,7 +630,10 @@ class MSCDBootstrap(Bootstrap):
         self._n_o = self._n_o[:self._n.size]
 
 
-def _bootstrap(array: np.ndarray, n_samples: int, n_resamples: int, random_state: np.random.mtrand.RandomState = None) -> list[float]:
+def _bootstrap(array: np.ndarray,
+               n_samples: int,
+               n_resamples: float,
+               random_state: np.random.mtrand.RandomState = None) -> list[float]:
     """
     Perform a set of resamples.
 
@@ -643,7 +646,7 @@ def _bootstrap(array: np.ndarray, n_samples: int, n_resamples: int, random_state
     :return: Simulated means from resampling the array.
     """
     return [
-        np.mean(resample(array.flatten(), n_samples=n_samples, random_state=random_state).flatten())
+        np.mean(resample(array.flatten(), n_samples=int(n_samples), random_state=random_state).flatten())
         for j in range(n_resamples)
     ]
     
@@ -669,6 +672,7 @@ def _bayesian_bootstrap(array: np.ndarray,
     
     :return: Samples from the simulated posterior distribution of the mean of the array.
     """
+    # n_samples = int(n_samples)
     if random_state == None:
         random_state = np.random.mtrand.RandomState()
     values = array.flatten()

--- a/kinisi/diffusion.py
+++ b/kinisi/diffusion.py
@@ -633,7 +633,7 @@ class MSCDBootstrap(Bootstrap):
 def _bootstrap(array: np.ndarray,
                n_samples: int,
                n_resamples: float,
-               random_state: np.random.mtrand.RandomState = None) -> list[float]:
+               random_state: np.random.mtrand.RandomState = None) -> List[float]:
     """
     Perform a set of resamples.
 
@@ -654,7 +654,7 @@ def _bootstrap(array: np.ndarray,
 def _bayesian_bootstrap(array: np.ndarray,
                         n_samples: float,
                         n_resamples: int,
-                        random_state: np.random.mtrand.RandomState = None) -> list[float]:
+                        random_state: np.random.mtrand.RandomState = None) -> List[float]:
     """
     Performs a Bayesian bootstrap simulation of the posterior distribution of the mean of observed values,
     using a sparse Dirichlet prior for sample weights.

--- a/kinisi/diffusion.py
+++ b/kinisi/diffusion.py
@@ -630,7 +630,7 @@ class MSCDBootstrap(Bootstrap):
         self._n_o = self._n_o[:self._n.size]
 
 
-def _bootstrap(array: np.ndarray, n_samples: int, n_resamples: int, random_state: np.random.mtrand.RandomState = None) -> np.ndarray:
+def _bootstrap(array: np.ndarray, n_samples: int, n_resamples: int, random_state: np.random.mtrand.RandomState = None) -> list[float]:
     """
     Perform a set of resamples.
 
@@ -651,7 +651,7 @@ def _bootstrap(array: np.ndarray, n_samples: int, n_resamples: int, random_state
 def _bayesian_bootstrap(array: np.ndarray,
                         n_samples: float,
                         n_resamples: int,
-                        random_state: np.random.mtrand.RandomState = None) -> np.ndarray:
+                        random_state: np.random.mtrand.RandomState = None) -> list[float]:
     """
     Performs a Bayesian bootstrap simulation of the posterior distribution of the mean of observed values,
     using a sparse Dirichlet prior for sample weights.
@@ -671,10 +671,11 @@ def _bayesian_bootstrap(array: np.ndarray,
     """
     if random_state == None:
         random_state = np.random.mtrand.RandomState()
-    k = len(array)
+    values = array.flatten()
+    k = len(values)
     alphak = (n_samples - 1)/(k - 1)
     weights = random_state.dirichlet(alpha=np.ones(k)*alphak, size=n_resamples)
-    return np.sum(weights * array, axis=1)
+    return list(np.sum(weights * values, axis=1))
 
 
 def _populate_covariance_matrix(variances: np.ndarray, n_samples: np.ndarray) -> np.ndarray:

--- a/kinisi/diffusion.py
+++ b/kinisi/diffusion.py
@@ -677,7 +677,11 @@ def _bayesian_bootstrap(array: np.ndarray,
     values = array.flatten()
     k = len(values)
     alphak = (n_samples - 1)/(k - 1)
-    weights = random_state.dirichlet(alpha=np.ones(k)*alphak, size=n_resamples)
+    if alphak > 0:
+        weights = random_state.dirichlet(alpha=np.ones(k)*alphak, size=n_resamples)
+    else:
+        # Sample from a uniform categorical distribution, equivalent to Dirichlet([0,0,0,…])
+        weights = random_state.multinomial(n=1, pvals=np.ones(k)/k, size=n_resamples)
     return list(np.sum(weights * values, axis=1))
 
 

--- a/kinisi/diffusion.py
+++ b/kinisi/diffusion.py
@@ -672,7 +672,6 @@ def _bayesian_bootstrap(array: np.ndarray,
     
     :return: Samples from the simulated posterior distribution of the mean of the array.
     """
-    # n_samples = int(n_samples)
     if random_state == None:
         random_state = np.random.mtrand.RandomState()
     values = array.flatten()

--- a/kinisi/parser.py
+++ b/kinisi/parser.py
@@ -157,7 +157,7 @@ class Parser:
     def get_disps(self,
                   timesteps: np.ndarray,
                   drift_corrected: np.ndarray,
-                  progress: bool = True) -> Tuple[np.ndarray, np.ndarray]:
+                  progress: bool = True) -> Tuple[np.ndarray, List[np.ndarray], np.ndarray]:
         """
         Calculate the displacement at each timestep.
 
@@ -203,7 +203,8 @@ class Parser:
             else:
                 raise ValueError(f"The sampling option of {self.sampling} is unrecognized, "
                                  "please use 'multi-origin' or 'single-origin'.")
-            n_samples = np.append(n_samples, np.multiply(*disp[:, ::timestep].shape[:2]))
+            # n_samples = np.append(n_samples, np.multiply(*disp[:, ::timestep].shape[:2]))
+            n_samples = np.append(n_samples, disp.shape[0] * timesteps[-1] / timestep)
         return delta_t, disp_3d, n_samples
 
 


### PR DESCRIPTION
Draft implementation of estimating var(MSD) using Bayesian bootstrap, using a sparsified Dirichlet prior to weight the observed data.
The number of independent (non-overlapping) observed displacements is now computed as an *effective* number of non-overlapping displacements — i.e., it includes fractional observations when Δt is not an integer factor of Δt_total.
