### PR TITLE
Using a Haven ratio-like heuristic for estimating concerted motion between atoms

### DIFF
--- a/kinisi/conductivity_analyzer.py
+++ b/kinisi/conductivity_analyzer.py
@@ -17,7 +17,7 @@ class ConductivityAnalyzer(Analyzer):
     """
     The :py:class:`kinisi.analyze.ConductivityAnalyzer` class performs analysis of conductive relationships in
     materials.
-    This is achieved through the application of a bootstrapping methodology to obtain the most statistically
+    This is achieved through the application of a Bayesian regression methodology to obtain the most statistically
     accurate values for mean squared charge displacement uncertainty and covariance.
     The time-dependence of the MSCD is then modelled in a generalised least squares fashion to obtain the jump
     diffusion coefficient and offset using Markov chain Monte Carlo maximum likelihood sampling.
@@ -27,8 +27,8 @@ class ConductivityAnalyzer(Analyzer):
         There is one array in the list for each delta_t value. Note: it is necessary to use a list of arrays as
         the number of observations is not necessary the same at each data point.
     :param volume: The volume of the simulation cell.
-    :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.DiffBootstrap` object. See
-        the appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+    :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.DiffDiffusion` object. See
+        the appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
     :param ionic_charge: The charge on the mobile ions, either an array with a value for each ion or a scalar
         if all values are the same. Optional, default is :py:attr:`1`.
     """
@@ -55,7 +55,7 @@ class ConductivityAnalyzer(Analyzer):
         :return: New :py:class`ConductivityAnalyzer` object.
         """
         cond_anal = cls(my_dict['delta_t'], my_dict['disp_3d'], my_dict['n_o'], my_dict['volume'])
-        cond_anal._diff = diffusion.Bootstrap.from_dict(my_dict['diff'])
+        cond_anal._diff = diffusion.Diffusion.from_dict(my_dict['diff'])
         return cond_anal
 
     @classmethod
@@ -78,8 +78,8 @@ class ConductivityAnalyzer(Analyzer):
             these constitute a series of :py:attr:`consecutive` trajectories or a series of :py:attr:`identical`
             starting points with different random seeds, in which case the `dtype` should be either
             :py:attr:`consecutive` or :py:attr:`identical`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
         :param ionic_charge: The charge on the mobile ions, either an array with a value for each ion or a scalar
             if all values are the same. Optional, default is :py:attr:`1`.
 
@@ -88,7 +88,7 @@ class ConductivityAnalyzer(Analyzer):
         if uncertainty_params is None:
             uncertainty_params = {}
         cond_anal = super()._from_pymatgen(trajectory, parser_params, dtype=dtype)
-        cond_anal._diff = diffusion.MSCDBootstrap(cond_anal._delta_t, cond_anal._disp_3d, ionic_charge, cond_anal._n_o,
+        cond_anal._diff = diffusion.MSCDDiffusion(cond_anal._delta_t, cond_anal._disp_3d, ionic_charge, cond_anal._n_o,
                                                   **uncertainty_params)
         return cond_anal
 
@@ -111,8 +111,8 @@ class ConductivityAnalyzer(Analyzer):
             these constitute a series of :py:attr:`consecutive` trajectories or a series of :py:attr:`identical`
             starting points with different random seeds, in which case the `dtype` should be either
             :py:attr:`consecutive` or :py:attr:`identical`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
         :param ionic_charge: The charge on the mobile ions, either an array with a value for each ion or a scalar
             if all values are the same. Optional, default is :py:attr:`1`.
 
@@ -121,7 +121,7 @@ class ConductivityAnalyzer(Analyzer):
         if uncertainty_params is None:
             uncertainty_params = {}
         cond_anal = super()._from_ase(trajectory, parser_params, dtype=dtype)
-        cond_anal._diff = diffusion.MSCDBootstrap(cond_anal._delta_t, cond_anal._disp_3d, ionic_charge, cond_anal._n_o,
+        cond_anal._diff = diffusion.MSCDDiffusion(cond_anal._delta_t, cond_anal._disp_3d, ionic_charge, cond_anal._n_o,
                                                   **uncertainty_params)
         return cond_anal
 
@@ -144,8 +144,8 @@ class ConductivityAnalyzer(Analyzer):
             then it is necessary to identify if these constitute a series of :py:attr:`consecutive` trajectories or a
             series of :py:attr:`identical` starting points with different random seeds, in which case the `dtype`
             should be either :py:attr:`consecutive` or :py:attr:`identical`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
         :param ionic_charge: The charge on the mobile ions, either an array with a value for each ion or a scalar
             if all values are the same. Optional, default is :py:attr:`1`.
 
@@ -154,7 +154,7 @@ class ConductivityAnalyzer(Analyzer):
         if uncertainty_params is None:
             uncertainty_params = {}
         cond_anal = super()._from_Xdatcar(trajectory, parser_params, dtype=dtype)
-        cond_anal._diff = diffusion.MSCDBootstrap(cond_anal._delta_t, cond_anal._disp_3d, ionic_charge, cond_anal._n_o,
+        cond_anal._diff = diffusion.MSCDDiffusion(cond_anal._delta_t, cond_anal._disp_3d, ionic_charge, cond_anal._n_o,
                                                   **uncertainty_params)
         return cond_anal
 
@@ -175,8 +175,8 @@ class ConductivityAnalyzer(Analyzer):
             list of files is passed, then it is necessary to identify if these constitute a series of
             :py:attr:`consecutive` trajectories or a series of :py:attr:`identical` starting points with different
             random seeds, in which case the `dtype` should be either :py:attr:`consecutive` or :py:attr:`identical`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
         :param ionic_charge: The charge on the mobile ions, either an array with a value for each ion or a scalar
             if all values are the same. Optional, default is :py:attr:`1`.
 
@@ -185,7 +185,7 @@ class ConductivityAnalyzer(Analyzer):
         if uncertainty_params is None:
             uncertainty_params = {}
         cond_anal = super()._from_file(trajectory, parser_params, dtype=dtype)
-        cond_anal._diff = diffusion.MSCDBootstrap(cond_anal._delta_t, cond_anal._disp_3d, ionic_charge, cond_anal._n_o,
+        cond_anal._diff = diffusion.MSCDDiffusion(cond_anal._delta_t, cond_anal._disp_3d, ionic_charge, cond_anal._n_o,
                                                   **uncertainty_params)
         return cond_anal
 
@@ -207,8 +207,8 @@ class ConductivityAnalyzer(Analyzer):
             :py:attr:`identical` starting points with different random seeds, in which case the `dtype` should
             be :py:attr:`identical`. For a series of consecutive trajectories, please construct the relevant
             object using :py:mod:`MDAnalysis`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
         :param ionic_charge: The charge on the mobile ions, either an array with a value for each ion or a scalar
             if all values are the same. Optional, default is :py:attr:`1`.
 
@@ -217,20 +217,20 @@ class ConductivityAnalyzer(Analyzer):
         if uncertainty_params is None:
             uncertainty_params = {}
         cond_anal = super()._from_universe(trajectory, parser_params, dtype=dtype)
-        cond_anal._diff = diffusion.MSCDBootstrap(cond_anal._delta_t, cond_anal._disp_3d, ionic_charge, cond_anal._n_o,
+        cond_anal._diff = diffusion.MSCDDiffusion(cond_anal._delta_t, cond_anal._disp_3d, ionic_charge, cond_anal._n_o,
                                                   **uncertainty_params)
         return cond_anal
 
     def conductivity(self, start_dt: float, temperature: float, conductivity_params: Union[dict, None] = None):
         """
-        Calculate the jump diffusion coefficicent using the bootstrap-GLS methodology.
+        Calculate the jump diffusion coefficicent using the Bayesian regression methodology.
 
         :param start_dt: The starting time for the analysis to find the diffusion coefficient.
             This should be the start of the diffusive regime in the simulation.
         :param temperature: Simulation temperature in Kelvin
-        :param conductivity_params: The parameters for the :py:class:`kinisi.diffusion.MSCDBootstrap` object.
+        :param conductivity_params: The parameters for the :py:class:`kinisi.diffusion.MSCDDiffusion` object.
             See the appropriate documentation for more guidance on this. Optional, default is the default
-            bootstrap parameters
+            diffusion parameters
         """
         if conductivity_params is None:
             conductivity_params = {}
@@ -239,8 +239,7 @@ class ConductivityAnalyzer(Analyzer):
     @property
     def mscd(self) -> np.ndarray:
         """
-        :return: MSCD for the input trajectories. Note that this is the bootstrap sampled value, not the numerical
-            average from the data.
+        :return: MSCD for the input trajectories.
         """
         return self._diff.n
 

--- a/kinisi/diffusion.py
+++ b/kinisi/diffusion.py
@@ -558,6 +558,7 @@ class MSDBootstrap(Bootstrap):
             import pyblock
             print('You are using the blocking method to estimate variances, please cite '
                   'doi:10.1063/1.457480 and the pyblock pacakge.')
+        self._f = np.array([])
         for i in self._iterator:
             disp_slice = self._displacements[i][:, :, self._slice].reshape(self._displacements[i].shape[0],
                                                                            self._displacements[i].shape[1], self.dims)

--- a/kinisi/diffusion.py
+++ b/kinisi/diffusion.py
@@ -485,7 +485,9 @@ class MSDDiffusion(Diffusion):
         delta_t value. Note: it is necessary to use a list of arrays as the number of observations is
         not necessary the same at each data point.
     :param n_o: Number of statistically independent observations of the MSD at each timestep.
-    :param sub_sample_dt: The frequency in observations to be sampled. Default is :py:attr:`1` (every observation)
+    :param sub_sample_dt: The frequency in observations to be sampled. Default is :py:attr:`1` (every observation).
+    :param correlation_normalisation: Perform a correlation normalisation based on the time-dependent 
+        Haven ratio. Default is :py:attr:`False`.
     :param block: Should the blocking method be used to estimate the variance, if :py:attr:`False` an 
         approximation is used to estimate the variance. Optional, default is :py:attr:`False`.
     :param dimension: Dimension/s to find the displacement along, this should be some subset of `'xyz'` indicating
@@ -500,6 +502,7 @@ class MSDDiffusion(Diffusion):
                  disp_3d: List[np.ndarray],
                  n_o: np.ndarray,
                  sub_sample_dt: int = 1,
+                 correlation_normalisation: bool = False,
                  block: bool = False,
                  dimension: str = 'xyz',
                  random_state: np.random.mtrand.RandomState = None,
@@ -514,8 +517,11 @@ class MSDDiffusion(Diffusion):
             disp_slice = self._displacements[i][:, :, self._slice].reshape(self._displacements[i].shape[0],
                                                                            self._displacements[i].shape[1], self.dims)
             d_squared = np.sum(disp_slice**2, axis=-1)
-            coll_motion = np.sum(np.sum(disp_slice, axis=0)**2, axis=-1) / disp_slice.shape[0]
-            hr = d_squared.mean() / coll_motion.mean()
+            if correlation_normalisation:
+                coll_motion = np.sum(np.sum(disp_slice, axis=0)**2, axis=-1) / disp_slice.shape[0]
+                hr = d_squared.mean() / coll_motion.mean()
+            else: 
+                hr = 1
             self._hr = np.append(self._hr, hr)
             if d_squared.size <= 1:
                 continue

--- a/kinisi/diffusion.py
+++ b/kinisi/diffusion.py
@@ -659,9 +659,9 @@ class MSTDBootstrap(Bootstrap):
                 self._v = np.append(self._v, var)
                 self._s = np.append(self._s, np.sqrt(self._v[i]))
             else:
-            self._n = np.append(self._n, coll_motion.mean())
-            self._v = np.append(self._v, np.var(coll_motion, ddof=1) / (n_o[i] / d_squared.shape[0]))
-            self._s = np.append(self._s, np.sqrt(self._v[i]))
+                self._n = np.append(self._n, coll_motion.mean())
+                self._v = np.append(self._v, np.var(coll_motion, ddof=1) / (n_o[i] / d_squared.shape[0]))
+                self._s = np.append(self._s, np.sqrt(self._v[i]))
             self._ngp = np.append(self._ngp, self.ngp_calculation(d_squared.flatten()))
             self._dt = np.append(self._dt, self._delta_t[i])
         self._n_o = self._n_o[:self._n.size]

--- a/kinisi/diffusion.py
+++ b/kinisi/diffusion.py
@@ -518,7 +518,7 @@ class MSDDiffusion(Diffusion):
                                                                            self._displacements[i].shape[1], self.dims)
             d_squared = np.sum(disp_slice**2, axis=-1)
             if correlation_normalisation:
-                coll_motion = np.sum(np.sum(disp_slice, axis=0)**2, axis=-1) / disp_slice.shape[0]
+                coll_motion = np.sum(np.sum(np.abs(disp_slice), axis=0)**2, axis=-1) / disp_slice.shape[0]
                 hr = d_squared.mean() / coll_motion.mean()
             else: 
                 hr = 1

--- a/kinisi/diffusion_analyzer.py
+++ b/kinisi/diffusion_analyzer.py
@@ -17,7 +17,7 @@ class DiffusionAnalyzer(Analyzer):
     """
     The :py:class:`kinisi.analyze.DiffusionAnalyzer` class performs analysis of diffusion relationships in
     materials.
-    This is achieved through the application of a bootstrapping methodology to obtain the most statistically
+    This is achieved through the application of a Bayesian regression methodology to obtain the most statistically
     accurate values for mean squared displacement uncertainty and estimating the covariance.
     The time-dependence of the MSD is then modelled in a generalised least squares fashion to obtain the diffusion
     coefficient and offset using Markov chain Monte Carlo maximum likelihood sampling.
@@ -27,8 +27,8 @@ class DiffusionAnalyzer(Analyzer):
         There is one array in the list for each delta_t value. Note: it is necessary to use a list of arrays as
         the number of observations is not necessary the same at each data point.
     :param volume: The volume of the simulation cell.
-    :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.DiffBootstrap` object. See
-        the appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+    :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.Diffusion` object. See
+        the appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
     """
 
     def __init__(self, delta_t: np.ndarray, disp_3d: List[np.ndarray], n_o: np.ndarray, volume: float):
@@ -53,7 +53,7 @@ class DiffusionAnalyzer(Analyzer):
         :return: New :py:class:`DiffusionAnalyzer` object.
         """
         diff_anal = cls(my_dict['delta_t'], my_dict['disp_3d'], my_dict['n_o'], my_dict['volume'])
-        diff_anal._diff = diffusion.Bootstrap.from_dict(my_dict['diff'])
+        diff_anal._diff = diffusion.Diffusion .from_dict(my_dict['diff'])
         return diff_anal
 
     @classmethod
@@ -76,15 +76,15 @@ class DiffusionAnalyzer(Analyzer):
             these constitute a series of :py:attr:`consecutive` trajectories or a series of :py:attr:`identical`
             starting points with different random seeds, in which case the `dtype` should be either
             :py:attr:`consecutive` or :py:attr:`identical`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion ` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion  parameters.
 
         :return: Relevant :py:class:`DiffusionAnalyzer` object.
         """
         if uncertainty_params is None:
             uncertainty_params = {}
         diff = super()._from_pymatgen(trajectory, parser_params, dtype=dtype)
-        diff._diff = diffusion.MSDBootstrap(diff._delta_t, diff._disp_3d, diff._n_o, **uncertainty_params)
+        diff._diff = diffusion.MSDDiffusion(diff._delta_t, diff._disp_3d, diff._n_o, **uncertainty_params)
         return diff
 
     @classmethod
@@ -106,15 +106,15 @@ class DiffusionAnalyzer(Analyzer):
             these constitute a series of :py:attr:`consecutive` trajectories or a series of :py:attr:`identical`
             starting points with different random seeds, in which case the `dtype` should be either
             :py:attr:`consecutive` or :py:attr:`identical`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion ` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
 
         :return: Relevant :py:class:`DiffusionAnalyzer` object.
         """
         if uncertainty_params is None:
             uncertainty_params = {}
         diff = super()._from_ase(trajectory, parser_params, dtype=dtype)
-        diff._diff = diffusion.MSDBootstrap(diff._delta_t, diff._disp_3d, diff._n_o, **uncertainty_params)
+        diff._diff = diffusion.MSDDiffusion(diff._delta_t, diff._disp_3d, diff._n_o, **uncertainty_params)
         return diff
 
     @classmethod
@@ -135,15 +135,15 @@ class DiffusionAnalyzer(Analyzer):
             then it is necessary to identify if these constitute a series of :py:attr:`consecutive` trajectories or a
             series of :py:attr:`identical` starting points with different random seeds, in which case the `dtype`
             should be either :py:attr:`consecutive` or :py:attr:`identical`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
 
         :return: Relevant :py:class:`DiffusionAnalyzer` object.
         """
         if uncertainty_params is None:
             uncertainty_params = {}
         diff = super()._from_Xdatcar(trajectory, parser_params, dtype=dtype)
-        diff._diff = diffusion.MSDBootstrap(diff._delta_t, diff._disp_3d, diff._n_o, **uncertainty_params)
+        diff._diff = diffusion.MSDDiffusion(diff._delta_t, diff._disp_3d, diff._n_o, **uncertainty_params)
         return diff
 
     @classmethod
@@ -162,15 +162,15 @@ class DiffusionAnalyzer(Analyzer):
             list of files is passed, then it is necessary to identify if these constitute a series of
             :py:attr:`consecutive` trajectories or a series of :py:attr:`identical` starting points with different
             random seeds, in which case the `dtype` should be either :py:attr:`consecutive` or :py:attr:`identical`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
 
         :return: Relevant :py:class:`DiffusionAnalyzer` object.
         """
         if uncertainty_params is None:
             uncertainty_params = {}
         diff = super()._from_file(trajectory, parser_params, dtype=dtype)
-        diff._diff = diffusion.MSDBootstrap(diff._delta_t, diff._disp_3d, diff._n_o, **uncertainty_params)
+        diff._diff = diffusion.MSDDiffusion(diff._delta_t, diff._disp_3d, diff._n_o, **uncertainty_params)
         return diff
 
     @classmethod
@@ -190,25 +190,25 @@ class DiffusionAnalyzer(Analyzer):
             :py:attr:`identical` starting points with different random seeds, in which case the `dtype` should
             be :py:attr:`identical`. For a series of consecutive trajectories, please construct the relevant
             object using :py:mod:`MDAnalysis`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
 
         :return: Relevant :py:class:`DiffusionAnalyzer` object.
         """
         if uncertainty_params is None:
             uncertainty_params = {}
         diff = super()._from_universe(trajectory, parser_params, dtype=dtype)
-        diff._diff = diffusion.MSDBootstrap(diff._delta_t, diff._disp_3d, diff._n_o, **uncertainty_params)
+        diff._diff = diffusion.MSDDiffusion(diff._delta_t, diff._disp_3d, diff._n_o, **uncertainty_params)
         return diff
 
     def diffusion(self, start_dt: float, diffusion_params: Union[dict, None] = None):
         """
-        Calculate the diffusion coefficicent using the bootstrap-GLS methodology.
+        Calculate the diffusion coefficicent using the Bayesian regression methodology.
 
         :param start_dt: The starting time for the analysis to find the diffusion coefficient.
             This should be the start of the diffusive regime in the simulation.
-        :param diffusion_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object.
-            See the appropriate documentation for more guidance on this. Optional, default is the default bootstrap
+        :param diffusion_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion` object.
+            See the appropriate documentation for more guidance on this. Optional, default is the default diffusion
             parameters.
         """
         if diffusion_params is None:
@@ -218,8 +218,7 @@ class DiffusionAnalyzer(Analyzer):
     @property
     def msd(self) -> np.ndarray:
         """
-        :return: MSD for the input trajectories. Note that this is the bootstrap sampled MSD, not the numerical
-        average from the data.
+        :return: MSD for the input trajectories.
         """
         return self._diff.n
 

--- a/kinisi/jump_diffusion_analyzer.py
+++ b/kinisi/jump_diffusion_analyzer.py
@@ -17,7 +17,7 @@ class JumpDiffusionAnalyzer(Analyzer):
     """
     The :py:class:`kinisi.analyze.JumpDiffusionAnalyzer` class performs analysis of collective diffusion
     relationships in materials.
-    This is achieved through the application of a bootstrapping methodology to obtain the most statistically
+    This is achieved through the application of a Bayesian regression methodology to obtain the most statistically
     accurate values for total mean squared displacement uncertainty and covariance.
     The time-dependence of the MSTD is then modelled in a generalised least squares fashion to obtain the jump
     diffusion coefficient and offset using Markov chain Monte Carlo maximum likelihood sampling.
@@ -27,8 +27,8 @@ class JumpDiffusionAnalyzer(Analyzer):
         There is one array in the list for each delta_t value. Note: it is necessary to use a list of arrays as
         the number of observations is not necessary the same at each data point.
     :param volume: The volume of the simulation cell.
-    :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.DiffBootstrap` object. See
-        the appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+    :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.DiffDiffusion` object. See
+        the appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
     """
 
     def __init__(self, delta_t: np.ndarray, disp_3d: List[np.ndarray], n_o: np.ndarray, volume: float):
@@ -53,7 +53,7 @@ class JumpDiffusionAnalyzer(Analyzer):
         :return: New :py:class:`DiffusionAnalyzer` object.
         """
         jdiff_anal = cls(my_dict['delta_t'], my_dict['disp_3d'], my_dict['n_o'], my_dict['volume'])
-        jdiff_anal._diff = diffusion.Bootstrap.from_dict(my_dict['diff'])
+        jdiff_anal._diff = diffusion.Diffusion.from_dict(my_dict['diff'])
         return jdiff_anal
 
     @classmethod
@@ -75,15 +75,15 @@ class JumpDiffusionAnalyzer(Analyzer):
             these constitute a series of :py:attr:`consecutive` trajectories or a series of :py:attr:`identical`
             starting points with different random seeds, in which case the `dtype` should be either
             :py:attr:`consecutive` or :py:attr:`identical`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
 
         :return: Relevant :py:class:`JumpDiffusionAnalyzer` object.
         """
         if uncertainty_params is None:
             uncertainty_params = {}
         jdiff_anal = super()._from_pymatgen(trajectory, parser_params, dtype=dtype)
-        jdiff_anal._diff = diffusion.MSTDBootstrap(jdiff_anal._delta_t, jdiff_anal._disp_3d, jdiff_anal._n_o,
+        jdiff_anal._diff = diffusion.MSTDDiffusion(jdiff_anal._delta_t, jdiff_anal._disp_3d, jdiff_anal._n_o,
                                                    **uncertainty_params)
         return jdiff_anal
 
@@ -105,15 +105,15 @@ class JumpDiffusionAnalyzer(Analyzer):
             these constitute a series of :py:attr:`consecutive` trajectories or a series of :py:attr:`identical`
             starting points with different random seeds, in which case the `dtype` should be either
             :py:attr:`consecutive` or :py:attr:`identical`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
         
         :return: Relevant :py:class:`JumpDiffusionAnalyzer` object.
         """
         if uncertainty_params is None:
             uncertainty_params = {}
         jdiff_anal = super()._from_ase(trajectory, parser_params, dtype=dtype)
-        jdiff_anal._diff = diffusion.MSTDBootstrap(jdiff_anal._delta_t, jdiff_anal._disp_3d, jdiff_anal._n_o,
+        jdiff_anal._diff = diffusion.MSTDDiffusion(jdiff_anal._delta_t, jdiff_anal._disp_3d, jdiff_anal._n_o,
                                                    **uncertainty_params)
         return jdiff_anal
 
@@ -135,15 +135,15 @@ class JumpDiffusionAnalyzer(Analyzer):
             then it is necessary to identify if these constitute a series of :py:attr:`consecutive` trajectories or a
             series of :py:attr:`identical` starting points with different random seeds, in which case the `dtype`
             should be either :py:attr:`consecutive` or :py:attr:`identical`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
 
         :return: Relevant :py:class:`JumpDiffusionAnalyzer` object.
         """
         if uncertainty_params is None:
             uncertainty_params = {}
         jdiff_anal = super()._from_Xdatcar(trajectory, parser_params, dtype=dtype)
-        jdiff_anal._diff = diffusion.MSTDBootstrap(jdiff_anal._delta_t, jdiff_anal._disp_3d, jdiff_anal._n_o,
+        jdiff_anal._diff = diffusion.MSTDDiffusion(jdiff_anal._delta_t, jdiff_anal._disp_3d, jdiff_anal._n_o,
                                                    **uncertainty_params)
         return jdiff_anal
 
@@ -163,15 +163,15 @@ class JumpDiffusionAnalyzer(Analyzer):
             list of files is passed, then it is necessary to identify if these constitute a series of
             :py:attr:`consecutive` trajectories or a series of :py:attr:`identical` starting points with different
             random seeds, in which case the `dtype` should be either :py:attr:`consecutive` or :py:attr:`identical`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
 
         :return: Relevant :py:class:`JumpDiffusionAnalyzer` object.
         """
         if uncertainty_params is None:
             uncertainty_params = {}
         jdiff_anal = super()._from_file(trajectory, parser_params, dtype=dtype)
-        jdiff_anal._diff = diffusion.MSTDBootstrap(jdiff_anal._delta_t, jdiff_anal._disp_3d, jdiff_anal._n_o,
+        jdiff_anal._diff = diffusion.MSTDDiffusion(jdiff_anal._delta_t, jdiff_anal._disp_3d, jdiff_anal._n_o,
                                                    **uncertainty_params)
         return jdiff_anal
 
@@ -192,27 +192,27 @@ class JumpDiffusionAnalyzer(Analyzer):
             :py:attr:`identical` starting points with different random seeds, in which case the `dtype` should
             be :py:attr:`identical`. For a series of consecutive trajectories, please construct the relevant
             object using :py:mod:`MDAnalysis`.
-        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDBootstrap` object. See the
-            appropriate documentation for more guidance on this. Optional, default is the default bootstrap parameters.
+        :param uncertainty_params: The parameters for the :py:class:`kinisi.diffusion.MSDDiffusion` object. See the
+            appropriate documentation for more guidance on this. Optional, default is the default diffusion parameters.
 
         :return: Relevant :py:class:`JumpDiffusionAnalyzer` object.
         """
         if uncertainty_params is None:
             uncertainty_params = {}
         jdiff_anal = super()._from_universe(trajectory, parser_params, dtype=dtype)
-        jdiff_anal._diff = diffusion.MSTDBootstrap(jdiff_anal._delta_t, jdiff_anal._disp_3d, jdiff_anal._n_o,
+        jdiff_anal._diff = diffusion.MSTDDiffusion(jdiff_anal._delta_t, jdiff_anal._disp_3d, jdiff_anal._n_o,
                                                    **uncertainty_params)
         return jdiff_anal
 
     def jump_diffusion(self, start_dt: float, jump_diffusion_params: Union[dict, None] = None):
         """
-        Calculate the jump diffusion coefficicent using the bootstrap-GLS methodology.
+        Calculate the jump diffusion coefficicent using the Bayesian regression methodology.
 
         :param start_dt: The starting time for the analysis to find the diffusion coefficient.
             This should be the start of the diffusive regime in the simulation.
-        :param ump_diffusion_params: The parameters for the :py:class:`kinisi.diffusion.MSTDBootstrap`
+        :param ump_diffusion_params: The parameters for the :py:class:`kinisi.diffusion.MSTDDiffusion`
             object. See the appropriate documentation for more guidance on this. Optional, default is the
-            default bootstrap parameters.
+            default diffusion parameters.
         """
         if jump_diffusion_params is None:
             jump_diffusion_params = {}
@@ -221,8 +221,7 @@ class JumpDiffusionAnalyzer(Analyzer):
     @property
     def mstd(self) -> np.ndarray:
         """
-        :return: MSTD for the input trajectories. Note that this is the bootstrap sampled MSD, not the numerical
-            average from the data.
+        :return: MSTD for the input trajectories. 
         """
         return self._diff.n
 

--- a/kinisi/tests/test_diffusion.py
+++ b/kinisi/tests/test_diffusion.py
@@ -656,4 +656,3 @@ class TestMSCDBootstrap(unittest.TestCase):
     #     assert_almost_equal(bs1.v, bs2.v)
     #     assert_almost_equal(bs1.covariance_matrix, bs2.covariance_matrix)
     #     assert_almost_equal(bs1.diffusion_coefficient.samples, bs2.diffusion_coefficient.samples)
-

--- a/kinisi/tests/test_diffusion.py
+++ b/kinisi/tests/test_diffusion.py
@@ -15,23 +15,23 @@ import warnings
 import numpy as np
 from tqdm import tqdm
 from numpy.testing import assert_almost_equal, assert_equal
-from kinisi.diffusion import Bootstrap, MSDBootstrap, MSTDBootstrap, MSCDBootstrap
+from kinisi.diffusion import Diffusion, MSDDiffusion, MSTDDiffusion, MSCDDiffusion
 from uravu.distribution import Distribution
 
 RNG = np.random.RandomState(43)
 
 
-class TestBootstrap(unittest.TestCase):
+class TestDiffusion(unittest.TestCase):
     """
-    Tests for the diffusion.Bootstrap class.
+    Tests for the diffusion.Diffusion class.
     """
 
     def test_dictionary_roundtrip(self):
         disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
         n_o = np.ones(len(disp_3d)) * 100
         dt = np.linspace(100, 1000, 10)
-        a = Bootstrap(dt, disp_3d, n_o)
-        b = Bootstrap.from_dict(a.to_dict())
+        a = Diffusion(dt, disp_3d, n_o)
+        b = Diffusion.from_dict(a.to_dict())
         for i, d in enumerate(disp_3d):
             assert_almost_equal(a._displacements[i], b._displacements[i])
         assert_almost_equal(a._delta_t, b._delta_t)
@@ -45,7 +45,7 @@ class TestBootstrap(unittest.TestCase):
         disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
         n_o = np.ones(len(disp_3d)) * 100
         dt = np.linspace(100, 1000, 10)
-        bs = Bootstrap(dt, disp_3d, n_o)
+        bs = Diffusion(dt, disp_3d, n_o)
         for i, d in enumerate(disp_3d):
             assert_almost_equal(bs._displacements[i], d)
         assert_almost_equal(bs._delta_t, dt)
@@ -59,7 +59,7 @@ class TestBootstrap(unittest.TestCase):
         disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
         n_o = np.ones(len(disp_3d)) * 100
         dt = np.linspace(100, 1000, 10)
-        bs = Bootstrap(dt, disp_3d, n_o, sub_sample_dt=2)
+        bs = Diffusion(dt, disp_3d, n_o, sub_sample_dt=2)
         for i, d in enumerate(disp_3d[::2]):
             assert_almost_equal(bs._displacements[i], d)
         assert_almost_equal(bs._delta_t, dt[::2])
@@ -70,21 +70,21 @@ class TestBootstrap(unittest.TestCase):
         assert bs.intercept is None
 
     def test_iterator_true(self):
-        result = Bootstrap.iterator(True, range(10))
+        result = Diffusion.iterator(True, range(10))
         assert isinstance(result, tqdm)
 
     def test_iterator_false(self):
-        result = Bootstrap.iterator(False, range(10))
+        result = Diffusion.iterator(False, range(10))
         assert isinstance(result, range)
 
     def test_ngp_calculation(self):
-        result = Bootstrap.ngp_calculation(np.array([1, 2, 3]))
+        result = Diffusion.ngp_calculation(np.array([1, 2, 3]))
         assert_almost_equal(result, -0.3)
 
 
-class TestMSDBootstrap(unittest.TestCase):
+class TestMSDDiffusion(unittest.TestCase):
     """
-    Tests for the diffusion.MSDBootstrap class.
+    Tests for the diffusion.MSDDiffusion class.
     """
 
     def test_dictionary_roundtrip(self):
@@ -92,8 +92,8 @@ class TestMSDBootstrap(unittest.TestCase):
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            a = MSDBootstrap(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
-            b = MSDBootstrap.from_dict(a.to_dict())
+            a = MSDDiffusion(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
+            b = MSDDiffusion.from_dict(a.to_dict())
             for i, d in enumerate(disp_3d):
                 assert_almost_equal(a._displacements[i], b._displacements[i])
             assert_almost_equal(a._delta_t, b._delta_t)
@@ -114,7 +114,7 @@ class TestMSDBootstrap(unittest.TestCase):
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSDBootstrap(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
+            bs = MSDDiffusion(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
             assert bs.n.shape == (10, )
             assert bs.s.shape == (10, )
             assert_almost_equal(bs.v, np.square(bs.s))
@@ -128,7 +128,7 @@ class TestMSDBootstrap(unittest.TestCase):
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs1 = MSDBootstrap(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
+            bs1 = MSDDiffusion(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
             assert bs1.n.shape == (10, )
             assert bs1.s.shape == (10, )
             assert_almost_equal(bs1.v, np.square(bs1.s))
@@ -136,14 +136,14 @@ class TestMSDBootstrap(unittest.TestCase):
             assert len(bs1.euclidian_displacements) == 10
             for i in bs1.euclidian_displacements:
                 assert isinstance(i, Distribution)
-            bs2 = MSDBootstrap(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
+            bs2 = MSDDiffusion(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
 
     def test_initialisation_progress(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSDBootstrap(dt, disp_3d, n_o, progress=False, random_state=np.random.RandomState(0))
+            bs = MSDDiffusion(dt, disp_3d, n_o, progress=False, random_state=np.random.RandomState(0))
             assert bs.n.shape == (10, )
             assert bs.s.shape == (10, )
             assert_almost_equal(bs.v, np.square(bs.s))
@@ -158,7 +158,7 @@ class TestMSDBootstrap(unittest.TestCase):
             disp_3d = [RNG.randn(1, i, 3) for i in range(10, 1, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSDBootstrap(dt, disp_3d, n_o, progress=False, random_state=np.random.RandomState(0))
+            bs = MSDDiffusion(dt, disp_3d, n_o, progress=False, random_state=np.random.RandomState(0))
             assert bs.n.shape == (9, )
             assert bs.s.shape == (9, )
             assert_almost_equal(bs.v, np.square(bs.s))
@@ -168,14 +168,14 @@ class TestMSDBootstrap(unittest.TestCase):
                 assert isinstance(i, Distribution)
             assert isinstance(bs._iterator, range)
 
-    def test_bootstrap_dictionary_roundtrip(self):
+    def test_diffusion_dictionary_roundtrip(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            a = MSDBootstrap(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
+            a = MSDDiffusion(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
             a.diffusion(0)
-            b = MSDBootstrap.from_dict(a.to_dict())
+            b = MSDDiffusion.from_dict(a.to_dict())
             for i, d in enumerate(disp_3d):
                 assert_almost_equal(a._displacements[i], b._displacements[i])
             assert_almost_equal(a._delta_t, b._delta_t)
@@ -191,12 +191,12 @@ class TestMSDBootstrap(unittest.TestCase):
             assert_equal(a._diffusion_coefficient.samples, b._diffusion_coefficient.samples)
             assert_equal(a.intercept.samples, b.intercept.samples)
 
-    def test_bootstrap(self):
+    def test_diffusion(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.diffusion(0)
             assert bs.covariance_matrix.shape == (10, 10)
             assert isinstance(bs._diffusion_coefficient, Distribution)
@@ -204,12 +204,12 @@ class TestMSDBootstrap(unittest.TestCase):
             assert bs._diffusion_coefficient.size == 3200
             assert bs.intercept.size == 3200
 
-    def test_bootstrap_dt_skip(self):
+    def test_diffusion_dt_skip(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSDBootstrap(dt, disp_3d, n_o)
+            bs = MSDDiffusion(dt, disp_3d, n_o)
             bs.diffusion(150)
             assert bs.covariance_matrix.shape == (9, 9)
             assert isinstance(bs._diffusion_coefficient, Distribution)
@@ -217,12 +217,12 @@ class TestMSDBootstrap(unittest.TestCase):
             assert bs._diffusion_coefficient.size == 3200
             assert bs.intercept.size == 3200
 
-    def test_bootstrap_use_ngp(self):
+    def test_diffusion_use_ngp(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(200, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 190)
-            bs = MSDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.diffusion(dt[bs.ngp.argmax()])
             assert bs.covariance_matrix.shape == (190 - np.argmax(bs.ngp), 190 - np.argmax(bs.ngp))
             assert isinstance(bs._diffusion_coefficient, Distribution)
@@ -230,24 +230,24 @@ class TestMSDBootstrap(unittest.TestCase):
             assert bs._diffusion_coefficient.size == 3200
             assert bs.intercept.size == 3200
 
-    def test_bootstrap_fit_intercept(self):
+    def test_diffusion_fit_intercept(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.diffusion(0, n_samples=500, fit_intercept=False)
             assert bs.covariance_matrix.shape == (10, 10)
             assert isinstance(bs._diffusion_coefficient, Distribution)
             assert bs._diffusion_coefficient.size == 1600
             assert bs.intercept is None
 
-    def test_bootstrap_n_samples(self):
+    def test_diffusion_n_samples(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.diffusion(0, n_samples=100)
             assert bs.covariance_matrix.shape == (10, 10)
             assert isinstance(bs._diffusion_coefficient, Distribution)
@@ -255,12 +255,12 @@ class TestMSDBootstrap(unittest.TestCase):
             assert bs._diffusion_coefficient.size == 320
             assert bs.intercept.size == 320
 
-    def test_bootstrap_D(self):
+    def test_diffusion_D(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.diffusion(0, n_samples=100)
             assert bs.covariance_matrix.shape == (10, 10)
             assert isinstance(bs._diffusion_coefficient, Distribution)
@@ -268,12 +268,12 @@ class TestMSDBootstrap(unittest.TestCase):
             assert bs.D.size == 320
             assert bs.intercept.size == 320
 
-    def test_bootstrap_thin(self):
+    def test_diffusion_thin(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.diffusion(dt[bs.ngp.argmax()], thin=1)
             assert bs.covariance_matrix.shape == (10 - np.argmax(bs.ngp), 10 - np.argmax(bs.ngp))
             assert isinstance(bs._diffusion_coefficient, Distribution)
@@ -281,12 +281,12 @@ class TestMSDBootstrap(unittest.TestCase):
             assert bs._diffusion_coefficient.size == 32000
             assert bs.intercept.size == 32000
 
-    def test_bootstrap_ppd(self):
+    def test_diffusion_ppd(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSTDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSTDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.diffusion(0)
             ppd = bs.posterior_predictive(128, 128)
             assert bs.covariance_matrix.shape == (5, 5)
@@ -300,21 +300,21 @@ class TestMSDBootstrap(unittest.TestCase):
     # def test_initialisation_random_state(self):
     #     disp_3d = [RNG.randn(100, i, 3) + 1000 for i in range(20, 10, -1)]
     #     dt = np.linspace(100, 1000, 10)
-    #     bs1 = DiffBootstrap(dt, disp_3d, n_walkers=5, n_samples=100, random_state=np.random.RandomState(0))
+    #     bs1 = DiffDiffusion(dt, disp_3d, n_walkers=5, n_samples=100, random_state=np.random.RandomState(0))
     #     assert bs1.covariance_matrix.shape == (10, 10)
     #     assert isinstance(bs1.diffusion_coefficient, Distribution)
     #     assert isinstance(bs1.intercept, Distribution)
     #     assert bs1.diffusion_coefficient.size == 500
     #     assert bs1.intercept.size == 500
-    #     bs2 = DiffBootstrap(dt, disp_3d, n_walkers=5, n_samples=100, random_state=np.random.RandomState(0))
+    #     bs2 = DiffDiffusion(dt, disp_3d, n_walkers=5, n_samples=100, random_state=np.random.RandomState(0))
     #     assert_almost_equal(bs1.v, bs2.v)
     #     assert_almost_equal(bs1.covariance_matrix, bs2.covariance_matrix)
     #     assert_almost_equal(bs1.diffusion_coefficient.samples, bs2.diffusion_coefficient.samples)
 
 
-class TestMSTDBootstrap(unittest.TestCase):
+class TestMSTDDiffusion(unittest.TestCase):
     """
-    Tests for the diffusion.MSTDBootstrap class.
+    Tests for the diffusion.MSTDDiffusion class.
     """
 
     def test_initialisation(self):
@@ -322,7 +322,7 @@ class TestMSTDBootstrap(unittest.TestCase):
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSTDBootstrap(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
+            bs = MSTDDiffusion(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
             assert bs.n.shape == (5, )
             assert bs.s.shape == (5, )
             assert_almost_equal(bs.v, np.square(bs.s))
@@ -336,7 +336,7 @@ class TestMSTDBootstrap(unittest.TestCase):
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs1 = MSTDBootstrap(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
+            bs1 = MSTDDiffusion(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
             assert bs1.n.shape == (5, )
             assert bs1.s.shape == (5, )
             assert_almost_equal(bs1.v, np.square(bs1.s))
@@ -344,14 +344,14 @@ class TestMSTDBootstrap(unittest.TestCase):
             assert len(bs1.euclidian_displacements) == 5
             for i in bs1.euclidian_displacements:
                 assert isinstance(i, Distribution)
-            bs2 = MSTDBootstrap(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
+            bs2 = MSTDDiffusion(dt, disp_3d, n_o, random_state=np.random.RandomState(0))
 
     def test_initialisation_progress(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSTDBootstrap(dt, disp_3d, n_o, progress=False, random_state=np.random.RandomState(0))
+            bs = MSTDDiffusion(dt, disp_3d, n_o, progress=False, random_state=np.random.RandomState(0))
             assert bs.n.shape == (5, )
             assert bs.s.shape == (5, )
             assert_almost_equal(bs.v, np.square(bs.s))
@@ -366,7 +366,7 @@ class TestMSTDBootstrap(unittest.TestCase):
             disp_3d = [RNG.randn(1, i, 3) for i in range(10, 1, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSTDBootstrap(dt, disp_3d, n_o, progress=False, random_state=np.random.RandomState(0))
+            bs = MSTDDiffusion(dt, disp_3d, n_o, progress=False, random_state=np.random.RandomState(0))
             assert bs.n.shape == (4, )
             assert bs.s.shape == (4, )
             assert_almost_equal(bs.v, np.square(bs.s))
@@ -376,12 +376,12 @@ class TestMSTDBootstrap(unittest.TestCase):
                 assert isinstance(i, Distribution)
             assert isinstance(bs._iterator, range)
 
-    def test_bootstrap(self):
+    def test_diffusion(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSTDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSTDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.jump_diffusion(0)
             assert bs.covariance_matrix.shape == (5, 5)
             assert isinstance(bs._jump_diffusion_coefficient, Distribution)
@@ -389,12 +389,12 @@ class TestMSTDBootstrap(unittest.TestCase):
             assert bs._jump_diffusion_coefficient.size == 3200
             assert bs.intercept.size == 3200
 
-    def test_bootstrap_use_ngp(self):
+    def test_diffusion_use_ngp(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSTDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSTDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.jump_diffusion(dt[bs.ngp.argmax()])
             assert bs.covariance_matrix.shape == (5 - np.argmax(bs.ngp), 5 - np.argmax(bs.ngp))
             assert isinstance(bs._jump_diffusion_coefficient, Distribution)
@@ -402,24 +402,24 @@ class TestMSTDBootstrap(unittest.TestCase):
             assert bs._jump_diffusion_coefficient.size == 3200
             assert bs.intercept.size == 3200
 
-    def test_bootstrap_fit_intercept(self):
+    def test_diffusion_fit_intercept(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSTDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSTDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.jump_diffusion(0, n_samples=500, fit_intercept=False)
             assert bs.covariance_matrix.shape == (5, 5)
             assert isinstance(bs._jump_diffusion_coefficient, Distribution)
             assert bs._jump_diffusion_coefficient.size == 1600
             assert bs.intercept is None
 
-    def test_bootstrap_n_samples(self):
+    def test_diffusion_n_samples(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSTDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSTDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.jump_diffusion(0, n_samples=100)
             assert bs.covariance_matrix.shape == (5, 5)
             assert isinstance(bs._jump_diffusion_coefficient, Distribution)
@@ -427,12 +427,12 @@ class TestMSTDBootstrap(unittest.TestCase):
             assert bs._jump_diffusion_coefficient.size == 320
             assert bs.intercept.size == 320
 
-    def test_bootstrap_D(self):
+    def test_diffusion_D(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSTDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSTDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.jump_diffusion(0, n_samples=100)
             assert bs.covariance_matrix.shape == (5, 5)
             assert isinstance(bs._jump_diffusion_coefficient, Distribution)
@@ -440,12 +440,12 @@ class TestMSTDBootstrap(unittest.TestCase):
             assert bs._jump_diffusion_coefficient.size == 320
             assert bs.intercept.size == 320
 
-    def test_bootstrap_thin(self):
+    def test_diffusion_thin(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(200, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 190)
-            bs = MSTDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSTDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.jump_diffusion(dt[bs.ngp.argmax()], thin=1)
             assert bs.covariance_matrix.shape == (95 - np.argmax(bs.ngp), 95 - np.argmax(bs.ngp))
             assert isinstance(bs._jump_diffusion_coefficient, Distribution)
@@ -453,12 +453,12 @@ class TestMSTDBootstrap(unittest.TestCase):
             assert bs._jump_diffusion_coefficient.size == 32000
             assert bs.intercept.size == 32000
 
-    def test_bootstrap_ppd(self):
+    def test_diffusion_ppd(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSTDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSTDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.jump_diffusion(0)
             ppd = bs.posterior_predictive(128, 128)
             assert bs.covariance_matrix.shape == (5, 5)
@@ -472,23 +472,23 @@ class TestMSTDBootstrap(unittest.TestCase):
     # def test_initialisation_random_state(self):
     #     disp_3d = [RNG.randn(100, i, 3) + 1000 for i in range(20, 10, -1)]
     #     dt = np.linspace(100, 1000, 10)
-    #     bs1 = MSTDBootstrap(dt, disp_3d, random_state=np.random.RandomState(0))
+    #     bs1 = MSTDDiffusion(dt, disp_3d, random_state=np.random.RandomState(0))
     #     bs1.jump_diffusion( n_walkers=5, n_samples=100, random_state=np.random.RandomState(0))
     #     assert bs1.covariance_matrix.shape == (10, 10)
     #     assert isinstance(bs1.diffusion_coefficient, Distribution)
     #     assert isinstance(bs1.intercept, Distribution)
     #     assert bs1.diffusion_coefficient.size == 500
     #     assert bs1.intercept.size == 500
-    #     bs2 = MSTDBootstrap(dt, disp_3d, random_state=np.random.RandomState(0))
+    #     bs2 = MSTDDiffusion(dt, disp_3d, random_state=np.random.RandomState(0))
     #     bs2.jump_diffusion( n_walkers=5, n_samples=100, random_state=np.random.RandomState(0))
     #     assert_almost_equal(bs1.v, bs2.v)
     #     assert_almost_equal(bs1.covariance_matrix, bs2.covariance_matrix)
     #     assert_almost_equal(bs1.diffusion_coefficient.samples, bs2.diffusion_coefficient.samples)
 
 
-class TestMSCDBootstrap(unittest.TestCase):
+class TestMSCDDiffusion(unittest.TestCase):
     """
-    Tests for the diffusion.MSCDBootstrap class.
+    Tests for the diffusion.MSCDDiffusion class.
     """
 
     def test_initialisation(self):
@@ -496,7 +496,7 @@ class TestMSCDBootstrap(unittest.TestCase):
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSCDBootstrap(dt, disp_3d, 1, n_o, random_state=np.random.RandomState(0))
+            bs = MSCDDiffusion(dt, disp_3d, 1, n_o, random_state=np.random.RandomState(0))
             assert bs.n.shape == (5, )
             assert bs.s.shape == (5, )
             assert_almost_equal(bs.v, np.square(bs.s))
@@ -510,7 +510,7 @@ class TestMSCDBootstrap(unittest.TestCase):
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs1 = MSCDBootstrap(dt, disp_3d, 1, n_o, random_state=np.random.RandomState(0))
+            bs1 = MSCDDiffusion(dt, disp_3d, 1, n_o, random_state=np.random.RandomState(0))
             assert bs1.n.shape == (5, )
             assert bs1.s.shape == (5, )
             assert_almost_equal(bs1.v, np.square(bs1.s))
@@ -518,14 +518,14 @@ class TestMSCDBootstrap(unittest.TestCase):
             assert len(bs1.euclidian_displacements) == 5
             for i in bs1.euclidian_displacements:
                 assert isinstance(i, Distribution)
-            bs2 = MSCDBootstrap(dt, disp_3d, 1, n_o, random_state=np.random.RandomState(0))
+            bs2 = MSCDDiffusion(dt, disp_3d, 1, n_o, random_state=np.random.RandomState(0))
 
     def test_initialisation_progress(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSCDBootstrap(dt, disp_3d, 1, n_o, progress=False, random_state=np.random.RandomState(0))
+            bs = MSCDDiffusion(dt, disp_3d, 1, n_o, progress=False, random_state=np.random.RandomState(0))
             assert bs.n.shape == (5, )
             assert bs.s.shape == (5, )
             assert_almost_equal(bs.v, np.square(bs.s))
@@ -540,7 +540,7 @@ class TestMSCDBootstrap(unittest.TestCase):
             disp_3d = [RNG.randn(1, i, 3) for i in range(10, 1, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSCDBootstrap(dt, disp_3d, 1, n_o, progress=False, random_state=np.random.RandomState(0))
+            bs = MSCDDiffusion(dt, disp_3d, 1, n_o, progress=False, random_state=np.random.RandomState(0))
             assert bs.n.shape == (4, )
             assert bs.s.shape == (4, )
             assert_almost_equal(bs.v, np.square(bs.s))
@@ -550,12 +550,12 @@ class TestMSCDBootstrap(unittest.TestCase):
                 assert isinstance(i, Distribution)
             assert isinstance(bs._iterator, range)
 
-    def test_bootstrap(self):
+    def test_diffusion(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSCDBootstrap(dt, disp_3d, 1, n_o, random_state=RNG)
+            bs = MSCDDiffusion(dt, disp_3d, 1, n_o, random_state=RNG)
             bs.conductivity(0, 1, 10)
             assert bs.covariance_matrix.shape == (5, 5)
             assert isinstance(bs.sigma, Distribution)
@@ -563,12 +563,12 @@ class TestMSCDBootstrap(unittest.TestCase):
             assert bs.sigma.size == 3200
             assert bs.intercept.size == 3200
 
-    def test_bootstrap_use_ngp(self):
+    def test_diffusion_use_ngp(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(200, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 190)
-            bs = MSCDBootstrap(dt, disp_3d, 1, n_o, random_state=RNG)
+            bs = MSCDDiffusion(dt, disp_3d, 1, n_o, random_state=RNG)
             bs.conductivity(dt[bs.ngp.argmax()], 1, 10)
             assert bs.covariance_matrix.shape == (95 - np.argmax(bs.ngp), 95 - np.argmax(bs.ngp))
             assert isinstance(bs.sigma, Distribution)
@@ -576,24 +576,24 @@ class TestMSCDBootstrap(unittest.TestCase):
             assert bs.sigma.size == 3200
             assert bs.intercept.size == 3200
 
-    def test_bootstrap_fit_intercept(self):
+    def test_diffusion_fit_intercept(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSCDBootstrap(dt, disp_3d, 1, n_o, random_state=RNG)
+            bs = MSCDDiffusion(dt, disp_3d, 1, n_o, random_state=RNG)
             bs.conductivity(0, 1, 10, n_samples=500, fit_intercept=False)
             assert bs.covariance_matrix.shape == (5, 5)
             assert isinstance(bs.sigma, Distribution)
             assert bs.sigma.size == 1600
             assert bs.intercept is None
 
-    def test_bootstrap_n_samples(self):
+    def test_diffusion_n_samples(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSCDBootstrap(dt, disp_3d, 1, n_o, random_state=RNG)
+            bs = MSCDDiffusion(dt, disp_3d, 1, n_o, random_state=RNG)
             bs.conductivity(0, 1, 10, n_samples=100)
             assert bs.covariance_matrix.shape == (5, 5)
             assert isinstance(bs.sigma, Distribution)
@@ -601,12 +601,12 @@ class TestMSCDBootstrap(unittest.TestCase):
             assert bs.sigma.size == 320
             assert bs.intercept.size == 320
 
-    def test_bootstrap_D(self):
+    def test_diffusion_D(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSCDBootstrap(dt, disp_3d, 1, n_o, random_state=RNG)
+            bs = MSCDDiffusion(dt, disp_3d, 1, n_o, random_state=RNG)
             bs.conductivity(0, 1, 10, n_samples=100)
             assert bs.covariance_matrix.shape == (5, 5)
             assert isinstance(bs.sigma, Distribution)
@@ -614,12 +614,12 @@ class TestMSCDBootstrap(unittest.TestCase):
             assert bs.sigma.size == 320
             assert bs.intercept.size == 320
 
-    def test_bootstrap_thin(self):
+    def test_diffusion_thin(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(210, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 190)
-            bs = MSCDBootstrap(dt, disp_3d, 1, n_o, random_state=RNG)
+            bs = MSCDDiffusion(dt, disp_3d, 1, n_o, random_state=RNG)
             bs.conductivity(dt[bs.ngp.argmax()], 1, 10, thin=1)
             assert bs.covariance_matrix.shape == (100 - np.argmax(bs.ngp), 100 - np.argmax(bs.ngp))
             assert isinstance(bs.sigma, Distribution)
@@ -627,12 +627,12 @@ class TestMSCDBootstrap(unittest.TestCase):
             assert bs.sigma.size == 32000
             assert bs.intercept.size == 32000
 
-    def test_bootstrap_ppd(self):
+    def test_diffusion_ppd(self):
         with warnings.catch_warnings(record=True) as _:
             disp_3d = [RNG.randn(100, i, 3) for i in range(20, 10, -1)]
             n_o = np.ones(len(disp_3d)) * 100
             dt = np.linspace(100, 1000, 10)
-            bs = MSTDBootstrap(dt, disp_3d, n_o, random_state=RNG)
+            bs = MSTDDiffusion(dt, disp_3d, n_o, random_state=RNG)
             bs.conductivity(0, 1, 10)
             ppd = bs.posterior_predictive(128, 128)
             assert bs.covariance_matrix.shape == (5, 5)
@@ -646,13 +646,13 @@ class TestMSCDBootstrap(unittest.TestCase):
     # def test_initialisation_random_state(self):
     #     disp_3d = [RNG.randn(100, i, 3) + 1000 for i in range(20, 10, -1)]
     #     dt = np.linspace(100, 1000, 10)
-    #     bs1 = DiffBootstrap(dt, disp_3d, n_samples=100, random_state=np.random.RandomState(0))
+    #     bs1 = DiffDiffusion(dt, disp_3d, n_samples=100, random_state=np.random.RandomState(0))
     #     assert bs1.covariance_matrix.shape == (10, 10)
     #     assert isinstance(bs1.diffusion_coefficient, Distribution)
     #     assert isinstance(bs1.intercept, Distribution)
     #     assert bs1.diffusion_coefficient.size == 500
     #     assert bs1.intercept.size == 500
-    #     bs2 = DiffBootstrap(dt, disp_3d, n_samples=100, random_state=np.random.RandomState(0))
+    #     bs2 = DiffDiffusion(dt, disp_3d, n_samples=100, random_state=np.random.RandomState(0))
     #     assert_almost_equal(bs1.v, bs2.v)
     #     assert_almost_equal(bs1.covariance_matrix, bs2.covariance_matrix)
     #     assert_almost_equal(bs1.diffusion_coefficient.samples, bs2.diffusion_coefficient.samples)


### PR DESCRIPTION
This PR will also remove the support for the bootstrap resampling approach to estimating the variance in a given mean-squared displacement. 