### PR TITLE
'Scipp'ification of the MDAnlysis parser 

### DIFF
--- a/kinisi/analyzer.py
+++ b/kinisi/analyzer.py
@@ -10,7 +10,8 @@ are intended for internal use.
 from typing import Union, List
 import numpy as np
 import scipp as sc
-from kinisi.parser import PymatgenParser,MDAnalysisParser, Parser
+from kinisi.parser import PymatgenParser, MDAnalysisParser, Parser
+
 
 class Analyzer:
     """
@@ -20,6 +21,7 @@ class Analyzer:
     :param trajectory: The parsed trajectory from some input file. This will be of type :py:class:`Parser`, but
         the specifics depend on the parser that is used. 
     """
+
     def __init__(self, trajectory: Parser) -> None:
         self.trajectory = trajectory
 
@@ -33,7 +35,7 @@ class Analyzer:
                       dt: sc.Variable = None,
                       dimension: str = 'xyz',
                       distance_unit: sc.Unit = sc.units.angstrom,
-                      progress: bool = True) -> 'Analyzer': 
+                      progress: bool = True) -> 'Analyzer':
         """
         Constructs the necessary :py:mod:`kinisi` objects for analysis from a single or a list of
         :py:class:`pymatgen.io.vasp.outputs.Xdatcar` objects.
@@ -61,10 +63,14 @@ class Analyzer:
         :param progress: Print progress bars to screen. Optional, defaults to :py:attr:`True`.
         """
         if dtype is None:
-            p = PymatgenParser(trajectory.structures, specie, time_step, step_skip, dt, dimension, distance_unit, progress)
+            p = PymatgenParser(trajectory.structures, specie, time_step, step_skip, dt, dimension, distance_unit,
+                               progress)
             return cls(p)
         elif dtype == 'identical':
-            u = [PymatgenParser(f.structures, specie, time_step, step_skip, dt, dimension, distance_unit, progress) for f in trajectory]
+            u = [
+                PymatgenParser(f.structures, specie, time_step, step_skip, dt, dimension, distance_unit, progress)
+                for f in trajectory
+            ]
             p = u[0]
             p.displacements = sc.concat([i.displacements for i in u], 'atom')
             return cls(p)
@@ -72,26 +78,33 @@ class Analyzer:
             structures = _flatten_list([x.structures for x in trajectory])
             p = PymatgenParser(structures, specie, time_step, step_skip, dt, dimension, distance_unit, progress)
             return cls(p)
-        
+
     @classmethod
     def _from_Universe(cls,
-                      trajectory: 'MDAnalysis.core.universe.Universe',
-                      specie: str,
-                      time_step: sc.Variable,
-                      step_skip: sc.Variable,
-                      dtype: Union[str, None] = None,
-                      dt: sc.Variable = None,
-                      dimension: str = 'xyz',
-                      distance_unit: sc.Unit = sc.units.angstrom,
-                      progress: bool = True) -> 'Analyzer':
+                       trajectory: 'MDAnalysis.core.universe.Universe',
+                       specie: str,
+                       time_step: sc.Variable,
+                       step_skip: sc.Variable,
+                       dtype: Union[str, None] = None,
+                       dt: sc.Variable = None,
+                       dimension: str = 'xyz',
+                       distance_unit: sc.Unit = sc.units.angstrom,
+                       progress: bool = True) -> 'Analyzer':
         """
         Constructs the necessary :py:mod:`kinisi` objects for analysis from a 
         :py:class:`MDAnalysis.core.universe.Universe` object.
         """
         if dtype is None:
-            p = MDAnalysisParser(universe= trajectory, specie=specie, time_step=time_step, step_skip=step_skip, dt = dt, dimension=dimension, distance_unit=distance_unit, progress=progress)
+            p = MDAnalysisParser(universe=trajectory,
+                                 specie=specie,
+                                 time_step=time_step,
+                                 step_skip=step_skip,
+                                 dt=dt,
+                                 dimension=dimension,
+                                 distance_unit=distance_unit,
+                                 progress=progress)
             return cls(p)
-        
+
     @property
     def distributions(self) -> np.array:
         """
@@ -99,10 +112,11 @@ class Analyzer:
         plotting of credible intervals.
         """
         if self.diff.intercept is not None:
-            return self.diff.gradient.values * self.mstd.coords['timestep'].values[:, np.newaxis] + self.diff.intercept.values
+            return self.diff.gradient.values * self.mstd.coords['timestep'].values[:, np.
+                                                                                   newaxis] + self.diff.intercept.values
         else:
             return self.diff.gradient.values * self.mstd.coords['timestep'].values[:, np.newaxis]
-        
+
 
 def _flatten_list(this_list: list) -> list:
     """

--- a/kinisi/analyzer.py
+++ b/kinisi/analyzer.py
@@ -10,7 +10,7 @@ are intended for internal use.
 from typing import Union, List
 import numpy as np
 import scipp as sc
-from kinisi.parser import PymatgenParser, Parser
+from kinisi.parser import PymatgenParser,MDAnalysisParser, Parser
 
 class Analyzer:
     """
@@ -71,6 +71,25 @@ class Analyzer:
         elif dtype == 'consecutive':
             structures = _flatten_list([x.structures for x in trajectory])
             p = PymatgenParser(structures, specie, time_step, step_skip, dt, dimension, distance_unit, progress)
+            return cls(p)
+        
+    @classmethod
+    def _from_Universe(cls,
+                      trajectory: 'MDAnalysis.core.universe.Universe',
+                      specie: str,
+                      time_step: sc.Variable,
+                      step_skip: sc.Variable,
+                      dtype: Union[str, None] = None,
+                      dt: sc.Variable = None,
+                      dimension: str = 'xyz',
+                      distance_unit: sc.Unit = sc.units.angstrom,
+                      progress: bool = True) -> 'Analyzer':
+        """
+        Constructs the necessary :py:mod:`kinisi` objects for analysis from a 
+        :py:class:`MDAnalysis.core.universe.Universe` object.
+        """
+        if dtype is None:
+            p = MDAnalysisParser(universe= trajectory, specie=specie, time_step=time_step, step_skip=step_skip, dt = dt, dimension=dimension, distance_unit=distance_unit, progress=progress)
             return cls(p)
         
     @property

--- a/kinisi/analyzer.py
+++ b/kinisi/analyzer.py
@@ -26,7 +26,7 @@ class Analyzer:
         self.trajectory = trajectory
 
     @classmethod
-    def _from_Xdatcar(cls,
+    def _from_xdatcar(cls,
                       trajectory: Union['pymatgen.io.vasp.outputs.Xdatcar', List['pymatgen.io.vasp.outputs.Xdatcar']],
                       specie: Union['pymatgen.core.periodic_table.Element', 'pymatgen.core.periodic_table.Specie'],
                       time_step: sc.Variable,
@@ -80,7 +80,7 @@ class Analyzer:
             return cls(p)
 
     @classmethod
-    def _from_Universe(cls,
+    def _from_universe(cls,
                        trajectory: 'MDAnalysis.core.universe.Universe',
                        specie: str,
                        time_step: sc.Variable,

--- a/kinisi/diffusion.py
+++ b/kinisi/diffusion.py
@@ -137,7 +137,6 @@ class Diffusion:
         self.bayesian_regression(start_dt=start_dt, **kwargs)
         self._diffusion_coefficient = sc.to_unit(self.gradient / (2 * self.msd.coords['dimensionality'].value), 'cm2/s')
 
-
     def jump_diffusion(self, start_dt: sc.Variable, **kwargs):
         """
         Calculation of the diffusion coefficient. 
@@ -147,7 +146,8 @@ class Diffusion:
         """
 
         self.bayesian_regression(start_dt=start_dt, **kwargs)
-        self._jump_diffusion_coefficient = sc.to_unit(self.gradient / (2 * self.msd.coords['dimensionality'].value * self.n_atoms), 'cm2/s')
+        self._jump_diffusion_coefficient = sc.to_unit(
+            self.gradient / (2 * self.msd.coords['dimensionality'].value * self.n_atoms), 'cm2/s')
 
     @property
     def D(self) -> sc.Variable:
@@ -155,7 +155,7 @@ class Diffusion:
         :return: The diffusion coefficient as a :py:mod:`scipp` object.
         """
         return self._diffusion_coefficient
-    
+
     @property
     def D_J(self) -> sc.Variable:
         """
@@ -177,7 +177,8 @@ class Diffusion:
                 cov[i, j] = value
                 cov[j, i] = np.copy(cov[i, j])
         return sc.array(dims=['time_interval1', 'time_interval2'],
-                        values=cov_nearest(minimum_eigenvalue_method(cov[self.diff_regime:, self.diff_regime:], self._cond_max)),
+                        values=cov_nearest(
+                            minimum_eigenvalue_method(cov[self.diff_regime:, self.diff_regime:], self._cond_max)),
                         unit=self.msd.unit**2)
 
 

--- a/kinisi/diffusion_analyzer.py
+++ b/kinisi/diffusion_analyzer.py
@@ -3,7 +3,7 @@ The :py:class:`kinisi.analyze.DiffusionAnalyser` class enable the evaluation of 
 displacment and the self-diffusion coefficient.
 """
 
-# Copyright (c) kinisi developers. 
+# Copyright (c) kinisi developers.
 # Distributed under the terms of the MIT License.
 # author: Andrew R. McCluskey (arm61)
 
@@ -23,14 +23,14 @@ class DiffusionAnalyzer(Analyzer):
     :param trajectory: The parsed trajectory from some input file. This will be of type :py:class:`Parser`, but
         the specifics depend on the parser that is used.
     """
+
     def __init__(self, trajectory: Parser) -> None:
         super().__init__(trajectory)
         self.msd = None
 
     @classmethod
     def from_Xdatcar(cls,
-                     trajectory: Union['pymatgen.io.vasp.outputs.Xdatcar',
-                                       List['pymatgen.io.vasp.outputs.Xdatcar']],
+                     trajectory: Union['pymatgen.io.vasp.outputs.Xdatcar', List['pymatgen.io.vasp.outputs.Xdatcar']],
                      specie: Union['pymatgen.core.periodic_table.Element', 'pymatgen.core.periodic_table.Specie'],
                      time_step: sc.Variable,
                      step_skip: sc.Variable,
@@ -67,10 +67,11 @@ class DiffusionAnalyzer(Analyzer):
         
         :returns: The :py:class:`DiffusionAnalyzer` object with the mean-squared displacement calculated.
         """
-        p = super()._from_Xdatcar(trajectory, specie, time_step, step_skip, dtype, dt, dimension, distance_unit, progress)
+        p = super()._from_Xdatcar(trajectory, specie, time_step, step_skip, dtype, dt, dimension, distance_unit,
+                                  progress)
         p.msd = calculate_msd(p.trajectory, progress)
         return p
-    
+
     @classmethod
     def from_Universe(cls,
                       trajectory: 'MDAnalysis.core.universe.Universe',
@@ -87,11 +88,17 @@ class DiffusionAnalyzer(Analyzer):
 
         :param trajectory: The :py:class:`MDAnalysis
         """
-        p = super()._from_Universe(trajectory = trajectory, specie = specie, time_step=time_step, step_skip=step_skip, dt=dt, dimension=dimension, distance_unit=distance_unit, progress=progress)
+        p = super()._from_Universe(trajectory=trajectory,
+                                   specie=specie,
+                                   time_step=time_step,
+                                   step_skip=step_skip,
+                                   dt=dt,
+                                   dimension=dimension,
+                                   distance_unit=distance_unit,
+                                   progress=progress)
         p.msd = calculate_msd(p.trajectory, progress)
         return p
-    
-    
+
     def diffusion(self, start_dt: sc.Variable, diffusion_params: Union[dict, None] = None) -> None:
         """
         Calculate the diffusion coefficient using the mean-squared displacement data.

--- a/kinisi/diffusion_analyzer.py
+++ b/kinisi/diffusion_analyzer.py
@@ -12,7 +12,7 @@ import numpy as np
 import scipp as sc
 from kinisi.displacement import calculate_msd
 from kinisi.diffusion import Diffusion
-from kinisi.parser import Parser, PymatgenParser
+from kinisi.parser import Parser, PymatgenParser, MDAnalysisParser
 from kinisi.analyzer import Analyzer
 
 
@@ -70,6 +70,27 @@ class DiffusionAnalyzer(Analyzer):
         p = super()._from_Xdatcar(trajectory, specie, time_step, step_skip, dtype, dt, dimension, distance_unit, progress)
         p.msd = calculate_msd(p.trajectory, progress)
         return p
+    
+    @classmethod
+    def from_Universe(cls,
+                      trajectory: 'MDAnalysis.core.universe.Universe',
+                      specie: str = None,
+                      time_step: sc.Variable = None,
+                      step_skip: sc.Variable = None,
+                      dt: sc.Variable = None,
+                      dimension: str = 'xyz',
+                      distance_unit: sc.Unit = sc.units.angstrom,
+                      progress: bool = True) -> 'DiffusionAnalyzer':
+        """
+        Constructs the necessary :py:mod:`kinisi` objects for analysis from a
+        :py:class:`MDAnalysis.Universe` object.
+
+        :param trajectory: The :py:class:`MDAnalysis
+        """
+        p = super()._from_Universe(trajectory = trajectory, specie = specie, time_step=time_step, step_skip=step_skip, dt=dt, dimension=dimension, distance_unit=distance_unit, progress=progress)
+        p.msd = calculate_msd(p.trajectory, progress)
+        return p
+    
     
     def diffusion(self, start_dt: sc.Variable, diffusion_params: Union[dict, None] = None) -> None:
         """

--- a/kinisi/diffusion_analyzer.py
+++ b/kinisi/diffusion_analyzer.py
@@ -67,7 +67,7 @@ class DiffusionAnalyzer(Analyzer):
         
         :returns: The :py:class:`DiffusionAnalyzer` object with the mean-squared displacement calculated.
         """
-        p = super()._from_Xdatcar(trajectory, specie, time_step, step_skip, dtype, dt, dimension, distance_unit,
+        p = super()._from_xdatcar(trajectory, specie, time_step, step_skip, dtype, dt, dimension, distance_unit,
                                   progress)
         p.msd = calculate_msd(p.trajectory, progress)
         return p
@@ -78,6 +78,7 @@ class DiffusionAnalyzer(Analyzer):
                       specie: str = None,
                       time_step: sc.Variable = None,
                       step_skip: sc.Variable = None,
+                      dtype: Union[str, None] = None,
                       dt: sc.Variable = None,
                       dimension: str = 'xyz',
                       distance_unit: sc.Unit = sc.units.angstrom,
@@ -88,14 +89,7 @@ class DiffusionAnalyzer(Analyzer):
 
         :param trajectory: The :py:class:`MDAnalysis
         """
-        p = super()._from_Universe(trajectory=trajectory,
-                                   specie=specie,
-                                   time_step=time_step,
-                                   step_skip=step_skip,
-                                   dt=dt,
-                                   dimension=dimension,
-                                   distance_unit=distance_unit,
-                                   progress=progress)
+        p = super()._from_universe(trajectory, specie, time_step, step_skip, dtype, dt, dimension, distance_unit, progress)
         p.msd = calculate_msd(p.trajectory, progress)
         return p
 

--- a/kinisi/displacement.py
+++ b/kinisi/displacement.py
@@ -39,8 +39,10 @@ def calculate_msd(p: parser.Parser, progress: bool = True) -> sc.Variable:
         msd_var.append(v)
         n_samples.append(n)
 
-
-    return sc.DataArray(data=sc.Variable(dims=['time interval'], values=np.array(msd, dtype = 'float64'), variances=msd_var, unit=s.unit),
+    return sc.DataArray(data=sc.Variable(dims=['time interval'],
+                                         values=np.array(msd, dtype='float64'),
+                                         variances=msd_var,
+                                         unit=s.unit),
                         coords={
                             'time interval': p.dt,
                             'n_samples': sc.array(dims=['time interval'], values=n_samples),

--- a/kinisi/displacement.py
+++ b/kinisi/displacement.py
@@ -9,6 +9,7 @@ Functions for the calculation of different types of displacement.
 import scipp as sc
 from tqdm import tqdm
 from kinisi import parser
+import numpy as np
 
 
 def calculate_msd(p: parser.Parser, progress: bool = True) -> sc.Variable:
@@ -37,7 +38,9 @@ def calculate_msd(p: parser.Parser, progress: bool = True) -> sc.Variable:
         msd.append(m)
         msd_var.append(v)
         n_samples.append(n)
-    return sc.DataArray(data=sc.Variable(dims=['time interval'], values=msd, variances=msd_var, unit=s.unit),
+
+
+    return sc.DataArray(data=sc.Variable(dims=['time interval'], values=np.array(msd, dtype = 'float64'), variances=msd_var, unit=s.unit),
                         coords={
                             'time interval': p.dt,
                             'n_samples': sc.array(dims=['time interval'], values=n_samples),

--- a/kinisi/parser.py
+++ b/kinisi/parser.py
@@ -225,3 +225,149 @@ class PymatgenParser(Parser):
         indices = sc.Variable(dims=['atom'], values=indices)
         drift_indices = sc.Variable(dims=['atom'], values=drift_indices)
         return indices, drift_indices
+
+
+class MDAnalysisParser(Parser):
+    """
+    Parser for MDAnalysis structures.
+
+    Takes an MDAnalysis.Universe object as an input. 
+
+    :param universe: MDanalysis universe object to be parsed
+    :param specie: Specie to calculate diffusivity for as a String, e.g. :py:attr:`'Li'`.
+    :param time_step: The input simulation time step, i.e., the time step for the molecular dynamics integrator. Note, 
+        that this must be given as a :py:mod:`scipp`-type scalar. The unit used for the time_step, will be the unit 
+        that is use for the time interval values.
+    :param step_skip: Sampling freqency of the simulation trajectory, i.e., how many time steps exist between the
+        output of the positions in the trajectory. Similar to the :py:attr:`time_step`, this parameter must be
+        a :py:mod:`scipp` scalar. The units for this scalar should be dimensionless.
+    :param dt: Time intervals to calculate the displacements over. Optional, defaults to a :py:mod:`scipp` array
+        ranging from the smallest interval (i.e., time_step * step_skip) to the full simulation length, with 
+        a step size the same as the smallest interval.
+    :param dimension: Dimension/s to find the displacement along, this should be some subset of `'xyz'` indicating
+        the axes of interest. Optional, defaults to `'xyz'`.
+    :param distance_unit: The unit of distance used in the input structures. Optional, defaults to angstroms.
+    :param sub_sample_atoms: Subsample the atoms in the trajectory. Optional, defaults to 1.
+    :param sub_sample_traj: Subsample the trajectory. Optional, defaults to 1.
+    :param progress: Whether to show a progress bar when reading in the structures. Optional, defaults to `True`.
+    """
+    def __init__(self,
+                universe: 'MDAnalysis.core.universe.Universe',
+                species: str,
+                time_step: sc.Variable,
+                step_skip: sc.Variable,
+                dt: sc.Variable = None,
+                dimension: str = 'xyz',
+                distance_unit: sc.Unit = sc.units.angstrom,
+                sub_sample_atoms: int = 1,
+                sub_sample_traj: int = 1,
+                progress: bool = True,
+                framework_indices: List[int] = None
+                 ):
+        
+        self.distance_unit = distance_unit
+    
+        structure, coords, latt = self.get_structure_coords_latt(universe, progress,sub_sample_atoms, sub_sample_traj)
+
+        indices, drift_indices = self.get_indices(structure, species, framework_indices)
+
+        print(coords)
+        print(dt)
+        print(time_step)
+        print(step_skip)
+
+        super().__init__(coords, latt, indices, drift_indices, time_step, step_skip, dt, dimension)
+
+        self._volume = structure.volume * self.distance_unit**3
+
+
+
+    def get_structure_coords_latt(
+            self,
+            universe: 'MDAnalysis.core.universe.Universe',
+            progress: bool = True,
+            sub_sample_atoms: int = 1,
+            sub_sample_traj: int = 1,) -> Tuple["MDAnalysis.core.universe.Universe", sc.Variable, sc.Variable]:
+        """
+        Obtain the initial structure, coordinates, and lattice parameters from an MDAnalysis.Universe object.
+
+        :param universe: MDanalysis universe object.
+        :param progress: Whether to show a progress bar when reading in the structures.
+        :param sub_sample_atoms: Subsample the atoms in the trajectory. Optional, defaults to 1.
+        :param sub_sample_traj: Subsample the trajectory. Optional, defaults to 1.
+
+        :returns: A tuple of the initial structure (as
+            a :py:class:`MDAnalysis.core.universe.Universe`), coordinates (as
+            a :py:mod:`scipp` array with dimensions of `time`, `atom`, and `dimension`),
+            and lattice parameters (as a :py:mod:`scipp` array with dimensions `time`,
+            `dimension1`, and `dimension2`).
+        """
+        first = True
+        coords_l = []
+        latt_l = []
+        if progress:
+            iterator = tqdm(universe.trajectory[::sub_sample_traj], desc='Reading Trajectory')
+        else:
+            iterator = universe.trajectory[::sub_sample_traj]
+
+        for struct in iterator:
+            if first:
+                structure = universe.atoms[::sub_sample_atoms]
+                first = False
+            matrix = np.array(struct.triclinic_dimensions)
+            inv_matrix = np.linalg.inv(matrix)
+            coords_l.append(np.dot(universe.atoms[::sub_sample_atoms].positions, inv_matrix))
+            latt_l.append(np.array(matrix))
+
+
+        coords_l = np.array(coords_l)
+        latt_l = np.array(latt_l)
+
+
+
+        coords = sc.array(dims=['time','atom', 'dimension'], values = coords_l, unit=sc.units.dimensionless)
+        latt = sc.array(dims=['time','dimension1', 'dimension2'], values = latt_l, unit=sc.units.angstrom)
+
+        return structure, coords, latt
+    
+
+    @staticmethod
+    def get_indices(structure: "MDAnalysis.universe.Universe", 
+                    specie: str,
+                    framework_indices: List[int]) -> Tuple[sc.Variable,sc.Variable]:
+        """
+        Determine framework and non-framework indices for an :py:mod:`MDAnalysis` compatible file.
+
+        :param structure: Initial structure.
+        :param specie: Specie to calculate diffusivity for as a String, e.g. :py:attr:`'Li'`.
+        :param framework_indices: Indices of framework to be used in drift correction. If set to None will return all indices that are not specie.
+
+        :return: Tuple containing: indices for the atoms in the trajectory used in the calculation of the
+            diffusion and indices of framework atoms.
+        """
+        indices = []
+        drift_indices = []
+
+
+        if not isinstance(specie, list):
+            specie = [specie]
+
+        for i, site in enumerate(structure):
+            if site.type in specie:
+                indices.append(i)
+            else:
+                drift_indices.append(i)
+
+        if len(indices) == 0:
+            raise ValueError("There are no species selected to calculate the mean-squared displacement of.")
+
+        if isinstance(framework_indices, (list, tuple)):
+            drift_indices = framework_indices
+
+        indices = sc.Variable(dims=['atom'], values=indices)
+        drift_indices = sc.Variable(dims=['atom'], values=drift_indices)
+
+        return indices, drift_indices
+        
+            
+

--- a/kinisi/parser.py
+++ b/kinisi/parser.py
@@ -251,37 +251,34 @@ class MDAnalysisParser(Parser):
     :param sub_sample_traj: Subsample the trajectory. Optional, defaults to 1.
     :param progress: Whether to show a progress bar when reading in the structures. Optional, defaults to `True`.
     """
+
     def __init__(self,
-                universe: 'MDAnalysis.core.universe.Universe',
-                specie: str,
-                time_step: sc.Variable,
-                step_skip: sc.Variable,
-                dt: sc.Variable = None,
-                dimension: str = 'xyz',
-                distance_unit: sc.Unit = sc.units.angstrom,
-                sub_sample_atoms: int = 1,
-                sub_sample_traj: int = 1,
-                progress: bool = True
-                 ):
-        
+                 universe: 'MDAnalysis.core.universe.Universe',
+                 specie: str,
+                 time_step: sc.Variable,
+                 step_skip: sc.Variable,
+                 dt: sc.Variable = None,
+                 dimension: str = 'xyz',
+                 distance_unit: sc.Unit = sc.units.angstrom,
+                 sub_sample_atoms: int = 1,
+                 sub_sample_traj: int = 1,
+                 progress: bool = True):
+
         self.distance_unit = distance_unit
 
-        structure, coords, latt = self.get_structure_coords_latt(universe, progress,sub_sample_atoms, sub_sample_traj)
+        structure, coords, latt = self.get_structure_coords_latt(universe, progress, sub_sample_atoms, sub_sample_traj)
 
         indices, drift_indices = self.get_indices(structure, specie)
 
         super().__init__(coords, latt, indices, drift_indices, time_step, step_skip, dt, dimension)
 
-       
-
-
-
     def get_structure_coords_latt(
-            self,
-            universe: 'MDAnalysis.core.universe.Universe',
-            progress: bool = True,
-            sub_sample_atoms: int = 1,
-            sub_sample_traj: int = 1,) -> Tuple["MDAnalysis.core.universe.Universe", sc.Variable, sc.Variable]:
+        self,
+        universe: 'MDAnalysis.core.universe.Universe',
+        progress: bool = True,
+        sub_sample_atoms: int = 1,
+        sub_sample_traj: int = 1,
+    ) -> Tuple["MDAnalysis.core.universe.Universe", sc.Variable, sc.Variable]:
         """
         Obtain the initial structure, coordinates, and lattice parameters from an MDAnalysis.Universe object.
 
@@ -313,20 +310,19 @@ class MDAnalysisParser(Parser):
             coords_l.append(np.dot(universe.atoms[::sub_sample_atoms].positions, inv_matrix))
             latt_l.append(np.array(matrix))
 
-
         coords_l = np.array(coords_l)
         latt_l = np.array(latt_l)
 
-        coords = sc.array(dims=['time','atom', 'dimension'], values = coords_l, unit=sc.units.dimensionless)
-        latt = sc.array(dims=['time','dimension1', 'dimension2'], values = latt_l, unit=self.distance_unit)
+        coords = sc.array(dims=['time', 'atom', 'dimension'], values=coords_l, unit=sc.units.dimensionless)
+        latt = sc.array(dims=['time', 'dimension1', 'dimension2'], values=latt_l, unit=self.distance_unit)
 
         return structure, coords, latt
-    
 
-    def get_indices(self,
-                    structure: "MDAnalysis.universe.Universe", 
-                    specie: str,
-                    ) -> Tuple[sc.Variable,sc.Variable]:
+    def get_indices(
+        self,
+        structure: "MDAnalysis.universe.Universe",
+        specie: str,
+    ) -> Tuple[sc.Variable, sc.Variable]:
         """
         Determine framework and non-framework indices for an :py:mod:`MDAnalysis` compatible file.
 
@@ -338,7 +334,7 @@ class MDAnalysisParser(Parser):
         """
         indices = []
         drift_indices = []
-    
+
         if not isinstance(specie, list):
             specie = [specie]
 
@@ -355,6 +351,3 @@ class MDAnalysisParser(Parser):
         drift_indices = sc.Variable(dims=['atom'], values=drift_indices)
 
         return indices, drift_indices
-        
-            
-

--- a/kinisi/parser.py
+++ b/kinisi/parser.py
@@ -260,13 +260,11 @@ class MDAnalysisParser(Parser):
                  dt: sc.Variable = None,
                  dimension: str = 'xyz',
                  distance_unit: sc.Unit = sc.units.angstrom,
-                 sub_sample_atoms: int = 1,
-                 sub_sample_traj: int = 1,
                  progress: bool = True):
 
         self.distance_unit = distance_unit
 
-        structure, coords, latt = self.get_structure_coords_latt(universe, progress, sub_sample_atoms, sub_sample_traj)
+        structure, coords, latt = self.get_structure_coords_latt(universe, progress)
 
         indices, drift_indices = self.get_indices(structure, specie)
 
@@ -276,8 +274,6 @@ class MDAnalysisParser(Parser):
         self,
         universe: 'MDAnalysis.core.universe.Universe',
         progress: bool = True,
-        sub_sample_atoms: int = 1,
-        sub_sample_traj: int = 1,
     ) -> Tuple["MDAnalysis.core.universe.Universe", sc.Variable, sc.Variable]:
         """
         Obtain the initial structure, coordinates, and lattice parameters from an MDAnalysis.Universe object.
@@ -297,17 +293,17 @@ class MDAnalysisParser(Parser):
         coords_l = []
         latt_l = []
         if progress:
-            iterator = tqdm(universe.trajectory[::sub_sample_traj], desc='Reading Trajectory')
+            iterator = tqdm(universe.trajectory, desc='Reading Trajectory')
         else:
-            iterator = universe.trajectory[::sub_sample_traj]
+            iterator = universe.trajectory
 
         for struct in iterator:
             if first:
-                structure = universe.atoms[::sub_sample_atoms]
+                structure = universe.atoms
                 first = False
             matrix = np.array(struct.triclinic_dimensions)
             inv_matrix = np.linalg.inv(matrix)
-            coords_l.append(np.dot(universe.atoms[::sub_sample_atoms].positions, inv_matrix))
+            coords_l.append(np.dot(universe.atoms.positions, inv_matrix))
             latt_l.append(np.array(matrix))
 
         coords_l = np.array(coords_l)
@@ -329,7 +325,7 @@ class MDAnalysisParser(Parser):
         :param structure: Initial structure.
         :param specie: Specie to calculate diffusivity for as a String, e.g. :py:attr:`'Li'`.
 
-        :return: Tuple containing: indices for the atoms in the trajectory used in the calculation of the
+        :return: Tuple containing indices for the atoms in the trajectory used in the calculation of the
             diffusion and indices of framework atoms.
         """
         indices = []


### PR DESCRIPTION
Implemented MDAnalysisparser with get_structure_coords_latt and get_indices. 

Things of note:

•Do we need to calculate volume within the parsers? - where do we then use it, I currently have not but can do if required, just an extra calc on the initial lattice. 
 
•Should  the fractional coordinates be dimensionless as discussed previously?
 
•Didn't implement the framework_indices stuff as you did not implement for the pymatgen parser, is this correct?
 
•Had to force the msd array to be float64 as MDAnalysis uses float32 by default
 
•I explicitly specified the function inputs for  _from_universe &  from_universe because something was breaking when i didn't will look into more tomorrow
